### PR TITLE
US127175 setting the max with to 723 + 2px for border

### DIFF
--- a/src/components/d2l-activity-question-points.js
+++ b/src/components/d2l-activity-question-points.js
@@ -29,6 +29,7 @@ class ActivityQuestionPoints extends HypermediaStateMixin(BaseMixin(LitElement))
 	static get styles() {
 		const activityQuestionPointsStyles = css`
 			.main_body {
+				max-width: 723px;
 				border: 1px solid var(--d2l-color-gypsum);
 				border-radius: 8px;
 			}


### PR DESCRIPTION
https://rally1.rallydev.com/#/15545269080d/iterationstatus?detail=%2Fuserstory%2F521713955728

- setting the max width to 725 as per the story. but really 723 because we have a 1 px border and the width in the image includes the border.
- There was a discrepancy on the header top/bottom margin but Gilberto was content to leave it at the default 30px 