### PR TITLE
use d2l-hc-description component

### DIFF
--- a/src/components/d2l-activity-question-usage.js
+++ b/src/components/d2l-activity-question-usage.js
@@ -3,7 +3,7 @@ import '@brightspace-ui/core/components/list/list-item-content.js';
 import '@brightspace-ui/core/components/inputs/input-number.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-hmc/foundation-components/components/activity/name/d2l-activity-name';
-import '@brightspace-hmc/foundation-components/components/activity/type/d2l-activity-type';
+import '@brightspace-hmc/foundation-components/components/common/d2l-hc-description';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin';
 import { BaseMixin } from '../mixins/base-mixin';
@@ -94,7 +94,7 @@ class ActivityQuestionUsage extends HypermediaStateMixin(BaseMixin(LitElement)) 
 					<d2l-hc-name href="${this._activityHref}" .token="${this.token}"></d2l-hc-name>
 				</div>
 				<div slot="secondary">
-					<d2l-activity-type href="${this._activityUsageHref}" .token="${this.token}"></d2l-activity-type>
+					<d2l-hc-description href="${this._activityHref}" .token="${this.token}"></d2l-hc-description>
 				</div>
 			</d2l-list-item-content>
 			<div class="activity_list__points_input" slot="actions">


### PR DESCRIPTION
We decided to add this change in quiz-components rather than change/add a custom component in foundation-components because:
- quiz-components already uses `d2l-hc-name` rather than `d2l-activity-name` because the latter is broken, so this is more consistent
- the custom component would just be a wrapper for `d2l-hc-description` whereas the existing custom description components wrap the description [differently](https://github.com/BrightspaceHypermediaComponents/foundation-components/blob/e9160fc75f60470cb16358919bc42e9f959d1408/components/activity/description/custom/DescriptionMixin.js#L13)

https://rally1.rallydev.com/#/15545269080d/iterationstatus?detail=%2Fuserstory%2F512795590868